### PR TITLE
会員登録の通知でパスワードでなく、パスワード再発行URL付けるように修正。他

### DIFF
--- a/Config/Migration/002_mail_setting_records.php
+++ b/Config/Migration/002_mail_setting_records.php
@@ -89,11 +89,10 @@ class UserManagerMailSettingRecords extends MailsMigration {
 				'mail_fixed_phrase_body' => 'Thank you for registering for {X-SITE_NAME}.
 Handle: {X-HANDLENAME}
 Login_id: {X-USERNAME}
-Password: {X-PASSWORD}
 e-mail: {X-EMAIL}
 
-You may now log in by clicking on this link or copying and pasting it in your browser:
-{X-URL}',
+New to get the password from the following, please login.:
+{X-PASSWORD_URL}',
 			),
 			// * 日本語
 			array(
@@ -105,11 +104,10 @@ You may now log in by clicking on this link or copying and pasting it in your br
 				'mail_fixed_phrase_body' => '会員登録が完了しましたのでお知らせします。
 ハンドル: {X-HANDLENAME}
 ログインID: {X-USERNAME}
-パスワード: {X-PASSWORD}
 e-mail: {X-EMAIL}
 
-下記アドレスからログインしてください。
-{X-URL}',
+下記から新たにパスワードを取得し、ログインてください。
+{X-PASSWORD_URL}',
 			),
 		),
 	);

--- a/Controller/UserAddController.php
+++ b/Controller/UserAddController.php
@@ -170,6 +170,9 @@ class UserAddController extends UserManagerAppController {
 					'class' => 'success',
 				));
 				if (Hash::get($this->request->data, '_UserManager.notify')) {
+					$user = Hash::insert(
+						$user, 'User.password', $this->Session->read('UserAdd.User.password')
+					);
 					$this->Session->write('UserAdd', $user);
 					return $this->redirect('/user_manager/user_add/notify');
 				} else {
@@ -259,10 +262,14 @@ class UserAddController extends UserManagerAppController {
 			if (! isset($password)) {
 				$password = '';
 			}
+
+			$passwordUrl = NetCommonsUrl::url('/auth/forgot_pass/request', true) .
+							'?email=' . $this->viewVars['user']['email'];
 			$mail->mailAssignTag->assignTags(array(
 				'X-HANDLENAME' => $this->viewVars['user']['handlename'],
 				'X-USERNAME' => $this->viewVars['user']['username'],
 				'X-PASSWORD' => $password,
+				'X-PASSWORD_URL' => $passwordUrl,
 				'X-EMAIL' => $this->viewVars['user']['email'],
 				'X-URL' => NetCommonsUrl::url('/', true),
 			));
@@ -271,7 +278,7 @@ class UserAddController extends UserManagerAppController {
 			$this->request->data['UserMail']['title'] = $mail->mailAssignTag->fixedPhraseSubject;
 			$this->request->data['UserMail']['body'] = $mail->mailAssignTag->fixedPhraseBody;
 			$this->request->data['UserMail']['user_id'] = $this->viewVars['user']['id'];
-			$this->request->data['UserMail']['reply_to'] = Current::read('User.email');
+			$this->request->data['UserMail']['from'] = SiteSettingUtil::read('Mail.from');
 		}
 	}
 

--- a/Controller/UserAddController.php
+++ b/Controller/UserAddController.php
@@ -227,11 +227,10 @@ class UserAddController extends UserManagerAppController {
 				$mail->mailAssignTag->setFixedPhraseBody($this->request->data['UserMail']['body']);
 				$mail->mailAssignTag->initPlugin(Current::read('Language.id'));
 
-				$mail->setReplyTo($this->request->data['UserMail']['reply_to']);
 				$mail->initPlugin(Current::read('Language.id'));
 
 				$mail->to($this->viewVars['user']['email']);
-				$mail->setFrom(Current::read('Language.id'));
+				$mail->from($this->request->data['UserMail']['from']);
 				if (! $mail->sendMailDirect()) {
 					return $this->NetCommons->handleValidationError(array('SendMail Error'));
 				}

--- a/Locale/jpn/LC_MESSAGES/user_manager.po
+++ b/Locale/jpn/LC_MESSAGES/user_manager.po
@@ -107,8 +107,8 @@ msgid "To mail address"
 msgstr "宛先(To)"
 
 #: UserManager/View/Elements/setting_tabs.ctp:38
-msgid "Reply to mail address"
-msgstr "返信用(Reply To)"
+msgid "From mail address"
+msgstr "差出人(From)"
 
 #: UserManager/View/Elements/setting_tabs.ctp:38
 msgid "Mail title"

--- a/Model/UserMail.php
+++ b/Model/UserMail.php
@@ -62,12 +62,12 @@ class UserMail extends UserManagerAppModel {
 					'message' => __d('net_commons', 'Invalid request.'),
 				),
 			),
-			'reply_to' => array(
+			'from' => array(
 				'email' => array(
 					'rule' => array('email'),
 					'message' => sprintf(
 						__d('net_commons', 'Unauthorized pattern for %s. Please input the data in %s format.'),
-						__d('user_manager', 'Reply to mail address'),
+						__d('user_manager', 'From mail address'),
 						__d('net_commons', 'email')
 					),
 					'required' => false,

--- a/Test/Case/Controller/UserAddController/NotifyTest.php
+++ b/Test/Case/Controller/UserAddController/NotifyTest.php
@@ -102,7 +102,7 @@ class UserAddControllerNotifyTest extends NetCommonsControllerTestCase {
 				'title' => '',
 				'body' => '',
 				'user_id' => '2',
-				'reply_to' => 'system_admin@exapmle.com'
+				'from' => 'system_admin@exapmle.com'
 			)
 		);
 		return $data;
@@ -144,38 +144,38 @@ class UserAddControllerNotifyTest extends NetCommonsControllerTestCase {
 			__d('net_commons', 'Please input %s.'),
 			__d('user_manager', 'Mail body')
 		);
-		$this->validationMessage['reply_to'] = sprintf(
+		$this->validationMessage['from'] = sprintf(
 			__d('net_commons', 'Unauthorized pattern for %s. Please input the data in %s format.'),
-			__d('user_manager', 'Reply to mail address'),
+			__d('user_manager', 'From mail address'),
 			__d('net_commons', 'email')
 		);
 
-		$replyTo = 'aaaaa';
+		$from = 'aaaaa';
 		$data = $this->__data();
-		$data = Hash::insert($data, 'UserMail.reply_to', $replyTo);
+		$data = Hash::insert($data, 'UserMail.from', $from);
 
 		//テスト実行
 		$this->_testPostAction('post', $data, array('action' => 'notify'), null, 'view');
 
 		//チェック
-		$this->__assert($replyTo);
+		$this->__assert($from);
 		$this->assertTextContains($this->validationMessage['title'], $this->view);
 		$this->assertTextContains($this->validationMessage['body'], $this->view);
-		$this->assertTextContains($this->validationMessage['reply_to'], $this->view);
+		$this->assertTextContains($this->validationMessage['from'], $this->view);
 	}
 
 /**
  * notify()アクションのチェック
  *
- * @param string $replyTo 返信用メールアドレス
+ * @param string $from 差出人メールアドレス
  * @return void
  */
-	private function __assert($replyTo = 'system_admin@exapmle.com') {
+	private function __assert($from = null) {
 		$this->assertInput('form', null, '/user_manager/user_add/notify', $this->view);
 		$this->assertInput('input', '_method', 'POST', $this->view);
 		$this->assertInput('input', 'data[UserMail][user_id]', '2', $this->view);
 		$this->assertInput('input', 'data[UserMail][to_address]', 'room_administrator@exapmle.com', $this->view);
-		$this->assertInput('input', 'data[UserMail][reply_to]', $replyTo, $this->view);
+		$this->assertInput('input', 'data[UserMail][from]', $from, $this->view);
 		$this->assertInput('input', 'data[UserMail][title]', '', $this->view);
 		$this->assertInput('input', 'data[UserMail][body]', '', $this->view);
 
@@ -184,7 +184,7 @@ class UserAddControllerNotifyTest extends NetCommonsControllerTestCase {
 				'title' => '',
 				'body' => '',
 				'user_id' => '2',
-				'reply_to' => $replyTo
+				'from' => $from
 			)
 		);
 		$this->assertEquals($expected, $this->controller->request->data);

--- a/View/UserAdd/notify.ctp
+++ b/View/UserAdd/notify.ctp
@@ -27,9 +27,9 @@
 					'value' => $user['email']
 				)); ?>
 
-			<?php echo $this->NetCommonsForm->input('UserMail.reply_to', array(
+			<?php echo $this->NetCommonsForm->input('UserMail.from', array(
 					'type' => 'text',
-					'label' => __d('user_manager', 'Reply to mail address'),
+					'label' => __d('user_manager', 'From mail address'),
 				)); ?>
 
 			<?php echo $this->NetCommonsForm->input('UserMail.title', array(


### PR DESCRIPTION
会員登録の通知でパスワードでなく、パスワード再発行URL付けるように修正。https://github.com/NetCommons3/UserManager/issues/56
X-PASSWORDの場合、ハッシュされたやつが表示されてしまっていた。https://github.com/NetCommons3/UserManager/issues/89
「返信用(Reply To)」は、メール設定にあわせて？Fromの名前とメルアドでは？https://github.com/NetCommons3/UserManager/issues/90
