### PR TITLE
CakePHP 2.10で、phpunit 4以降に対応

### DIFF
--- a/Test/Case/Controller/UserAddController/BasicTest.php
+++ b/Test/Case/Controller/UserAddController/BasicTest.php
@@ -83,6 +83,9 @@ class UserAddControllerBasicTest extends UserManagerControllerTestCase {
 		$this->generateNc(Inflector::camelize($this->_controller), array(
 			'components' => array('Session' => array('read'))
 		));
+		//ログイン
+		TestAuthGeneral::login($this);
+
 		if (Configure::read('debug')) {
 			$exactly = 2;
 		} else {
@@ -120,6 +123,9 @@ class UserAddControllerBasicTest extends UserManagerControllerTestCase {
 		$this->generateNc(Inflector::camelize($this->_controller), array(
 			'components' => array('Session' => array('read'))
 		));
+		//ログイン
+		TestAuthGeneral::login($this);
+
 		$data = $this->__data();
 		if (Configure::read('debug')) {
 			$exactly = 2;
@@ -153,6 +159,8 @@ class UserAddControllerBasicTest extends UserManagerControllerTestCase {
 		$this->generateNc(Inflector::camelize($this->_controller), array(
 			'components' => array('Session' => array('write'))
 		));
+		//ログイン
+		TestAuthGeneral::login($this);
 
 		//テストデータ
 		$this->_mockForReturnTrue('Users.User', 'validateUser');
@@ -182,6 +190,9 @@ class UserAddControllerBasicTest extends UserManagerControllerTestCase {
 				)
 			)
 		));
+
+		//ログイン
+		TestAuthGeneral::login($this);
 
 		//事前準備
 		$uploadPath = TMP . 'uploads';

--- a/Test/Case/Controller/UserAddController/BeforeFilterTest.php
+++ b/Test/Case/Controller/UserAddController/BeforeFilterTest.php
@@ -110,6 +110,9 @@ class UserAddControllerBeforeFilterTest extends UserManagerControllerTestCase {
 			'components' => array('Session' => array('read'))
 		));
 
+		//ログイン
+		TestAuthGeneral::login($this);
+
 		$user = array(
 			'id' => '',
 			'email' => '',

--- a/Test/Case/Controller/UserAddController/DownloadTest.php
+++ b/Test/Case/Controller/UserAddController/DownloadTest.php
@@ -60,6 +60,9 @@ class UserAddControllerDownloadTest extends UserManagerControllerTestCase {
 			'components' => array('Session' => array('read'))
 		));
 
+		//ログイン
+		TestAuthGeneral::login($this);
+
 		$path = App::pluginPath('UserManager') . 'Test' . DS . 'Fixture' . DS . 'logo.gif';
 		$this->controller->Session
 			->expects($this->once())->method('read')
@@ -81,6 +84,9 @@ class UserAddControllerDownloadTest extends UserManagerControllerTestCase {
 		$this->generateNc(Inflector::camelize($this->_controller), array(
 			'components' => array('Session' => array('read'))
 		));
+
+		//ログイン
+		TestAuthGeneral::login($this);
 
 		$this->controller->Session
 			->expects($this->once())->method('read')

--- a/Test/Case/Controller/UserAddController/NotifyTest.php
+++ b/Test/Case/Controller/UserAddController/NotifyTest.php
@@ -51,6 +51,10 @@ class UserAddControllerNotifyTest extends NetCommonsControllerTestCase {
 	public function setUp() {
 		parent::setUp();
 
+		$this->generateNc(Inflector::camelize($this->_controller), array('components' => array(
+			'Flash' => array('set')
+		)));
+
 		//ログイン
 		TestAuthGeneral::login($this);
 
@@ -174,8 +178,8 @@ class UserAddControllerNotifyTest extends NetCommonsControllerTestCase {
 			->expects($this->once())->method('sendMailDirect')
 			->will($this->returnValue(true));
 
-		$this->controller->Components->Session
-			->expects($this->once())->method('setFlash')
+		$this->controller->Flash->expects($this->once())
+			->method('set')
 			->with(__d('user_manager', 'Successfully mail send.'));
 
 		//テスト実行
@@ -199,8 +203,8 @@ class UserAddControllerNotifyTest extends NetCommonsControllerTestCase {
 			->expects($this->once())->method('sendMailDirect')
 			->will($this->returnValue(false));
 
-		$this->controller->Components->Session
-			->expects($this->once())->method('setFlash')
+		$this->controller->Flash->expects($this->once())
+			->method('set')
 			->with(__d('net_commons', 'Failed on validation errors. Please check the input data.'));
 
 		//テスト実行
@@ -223,8 +227,8 @@ class UserAddControllerNotifyTest extends NetCommonsControllerTestCase {
 				throw new BadRequestException();
 			}));
 
-		$this->controller->Components->Session
-			->expects($this->once())->method('setFlash')
+		$this->controller->Flash->expects($this->once())
+			->method('set')
 			->with(__d('mails', 'There is errors in the mail settings. It was not able to send mail.'));
 
 		//テスト実行

--- a/Test/Case/Controller/UserAddController/UserRolesRoomsTest.php
+++ b/Test/Case/Controller/UserAddController/UserRolesRoomsTest.php
@@ -34,6 +34,10 @@ class UserAddControllerUserRolesRoomsTest extends UserManagerControllerTestCase 
 	public function setUp() {
 		parent::setUp();
 
+		$this->generateNc(Inflector::camelize($this->_controller), array('components' => array(
+			'Flash' => array('set')
+		)));
+
 		//ログイン
 		TestAuthGeneral::login($this);
 	}
@@ -218,8 +222,8 @@ class UserAddControllerUserRolesRoomsTest extends UserManagerControllerTestCase 
 			->expects($this->exactly(2))->method('delete')
 			->will($this->returnValue(true));
 
-		$this->controller->Components->Session
-			->expects($this->once())->method('setFlash')
+		$this->controller->Flash->expects($this->once())
+			->method('set')
 			->with(__d('net_commons', 'Successfully saved.'));
 
 		$this->_mockForReturnTrue('Users.User', 'saveUser');
@@ -257,8 +261,8 @@ class UserAddControllerUserRolesRoomsTest extends UserManagerControllerTestCase 
 				return Hash::get($user, $name);
 			}));
 
-		$this->controller->Components->Session
-			->expects($this->once())->method('setFlash')
+		$this->controller->Flash->expects($this->once())
+			->method('set')
 			->with(__d('net_commons', 'Successfully saved.'));
 
 		$this->controller->Components->Session
@@ -327,6 +331,10 @@ class UserAddControllerUserRolesRoomsTest extends UserManagerControllerTestCase 
 		$this->generateNc(Inflector::camelize($this->_controller), array(
 			'components' => array('NetCommons.NetCommons' => array('handleValidationError'))
 		));
+
+		//ログイン
+		TestAuthGeneral::login($this);
+
 		$this->_mockForReturnFalse('Users.User', 'saveUser');
 
 		$this->controller->NetCommons

--- a/Test/Case/Controller/UserManagerController/DeleteTest.php
+++ b/Test/Case/Controller/UserManagerController/DeleteTest.php
@@ -83,15 +83,15 @@ class UserManagerControllerDeleteTest extends UserManagerControllerTestCase {
  * @return void
  */
 	public function testDelete() {
-		//ログイン
-		TestAuthGeneral::login($this);
-
 		//テストデータ
 		$this->generateNc(Inflector::camelize($this->_controller), array(
 			'components' => array(
 				'NetCommons.NetCommons' => array('setFlashNotification'),
 			)
 		));
+
+		//ログイン
+		TestAuthGeneral::login($this);
 
 		$userId = '2';
 		$this->_mockForReturnTrue('Users.User', 'deleteUser');

--- a/Test/Case/Controller/UserManagerController/DownloadTest.php
+++ b/Test/Case/Controller/UserManagerController/DownloadTest.php
@@ -34,9 +34,6 @@ class UserManagerControllerDownloadTest extends UserManagerControllerTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		//ログイン
-		TestAuthGeneral::login($this);
-
 		//事前準備
 		$this->_testApp = App::pluginPath('Users') . DS . 'Test' . DS . 'test_app' . DS;
 		$this->_testWebroot = $this->_testApp . 'webroot' . DS;
@@ -48,6 +45,9 @@ class UserManagerControllerDownloadTest extends UserManagerControllerTestCase {
 				'Files.Download' => array('doDownload')
 			)
 		));
+
+		//ログイン
+		TestAuthGeneral::login($this);
 	}
 
 /**


### PR DESCRIPTION
・Session->setFlashを使わないようにしたことによる修正
・generateNcの後にログイン処理をするように修正
https://github.com/NetCommons3/NetCommons3/issues/998