### PR TITLE
refs NetCommons3/NetCommons3/issues/1226

### DIFF
--- a/Controller/UserManagerAppController.php
+++ b/Controller/UserManagerAppController.php
@@ -21,6 +21,13 @@ App::uses('Space', 'Rooms.Model');
 class UserManagerAppController extends AppController {
 
 /**
+ * session name
+ *
+ * @var string
+ */
+	const USER_MANAGER_SEARCH_CONDITIONS = 'UserManagerSearchConditions';
+
+/**
  * use component
  *
  * @var array

--- a/Controller/UserManagerController.php
+++ b/Controller/UserManagerController.php
@@ -95,6 +95,13 @@ class UserManagerController extends UserManagerAppController {
 			))
 		]);
 
+		$queries = $this->request->query;
+		if (! empty($queries)) {
+			$this->Session->write(self::USER_MANAGER_SEARCH_CONDITIONS, $queries);
+		} else {
+			$this->Session->delete(self::USER_MANAGER_SEARCH_CONDITIONS);
+		}
+
 		$this->helpers[] = 'Users.UserSearch';
 	}
 
@@ -171,16 +178,20 @@ class UserManagerController extends UserManagerAppController {
 				$this->NetCommons->setFlashNotification(
 					__d('net_commons', 'Successfully saved.'), array('class' => 'success')
 				);
-				return $this->redirect('/user_manager/user_manager/index');
+				$user = $this->User->getUser($userId);
+			} else {
+				$this->NetCommons->handleValidationError($this->User->validationErrors);
+				$this->request->data = Hash::merge($user, $this->request->data);
 			}
-			$this->NetCommons->handleValidationError($this->User->validationErrors);
-			$this->request->data = Hash::merge($user, $this->request->data);
 
 		} else {
 			//表示処理
 			$this->User->languages = $this->viewVars['languages'];
 			$this->request->data = $user;
 		}
+
+		// 絞り込み条件
+		$this->set('query', $this->Session->read(self::USER_MANAGER_SEARCH_CONDITIONS));
 
 		$this->set('user', $user['User']);
 		$this->set('userName', $this->request->data['User']['handlename']);

--- a/Controller/UsersRolesRoomsController.php
+++ b/Controller/UsersRolesRoomsController.php
@@ -80,7 +80,6 @@ class UsersRolesRoomsController extends UserManagerAppController {
 				$this->NetCommons->setFlashNotification(__d('net_commons', 'Successfully saved.'), array(
 					'class' => 'success',
 				));
-				return $this->redirect('/user_manager/user_manager/index');
 			} else {
 				//異常処理
 				$this->NetCommons->handleValidationError($this->RolesRoomsUser->validationErrors);
@@ -108,6 +107,9 @@ class UsersRolesRoomsController extends UserManagerAppController {
 			$rolesRoomsUsers, '{n}.RolesRoomsUser.room_id', '{n}.RolesRoomsUser'
 		);
 		$this->set('rolesRoomsUsers', $rolesRoomsUsers);
+
+		//** 絞り込み条件
+		$this->set('query', $this->Session->read(self::USER_MANAGER_SEARCH_CONDITIONS));
 	}
 
 }

--- a/Locale/eng/LC_MESSAGES/user_manager.po
+++ b/Locale/eng/LC_MESSAGES/user_manager.po
@@ -91,6 +91,10 @@ msgstr ""
 #: UserManager/View/UserManager/edit.ctp:18
 msgid "Input the user data, and press [OK].<br>Required items are marked by <strong class=\"text-danger h4\">*</strong>."
 msgstr ""
+msgid "Back to list"
+msgstr ""
+msgid "Back to search result list"
+msgstr ""
 
 #: UserManager/View/UserManager/export.ctp:19
 msgid "Export title"

--- a/Locale/jpn/LC_MESSAGES/user_manager.po
+++ b/Locale/jpn/LC_MESSAGES/user_manager.po
@@ -89,6 +89,10 @@ msgstr "会員の基本項目を入力して[次へ]を押してください。<
 msgid "Input the user data, and press [OK].<br>Required items are marked by <strong class="text-danger h4">*</strong>."
 msgstr "会員の基本項目を入力して[決定]を押してください。<br><strong class="text-danger h4">*</strong> 印の項目は必須入力項目です。"
 
+msgid "Back to list"
+msgstr "一覧に戻る"
+msgid "Back to search result list"
+msgstr "絞り込み一覧に戻る"
 
 #
 # 参加ルームの選択

--- a/Locale/user_manager.pot
+++ b/Locale/user_manager.pot
@@ -91,6 +91,10 @@ msgstr ""
 #: UserManager/View/UserManager/edit.ctp:18
 msgid "Input the user data, and press [OK].<br>Required items are marked by <strong class=\"text-danger h4\">*</strong>."
 msgstr ""
+msgid "Back to list"
+msgstr ""
+msgid "Back to search result list"
+msgstr ""
 
 #: UserManager/View/UserManager/export.ctp:19
 msgid "Export title"

--- a/Test/Case/Controller/UserManagerController/EditTest.php
+++ b/Test/Case/Controller/UserManagerController/EditTest.php
@@ -252,8 +252,8 @@ class UserManagerControllerEditTest extends UserManagerControllerTestCase {
 		// 同じ画面にとどまっていることを確認する
 		// 改行コードや微妙な空白などの混在がチェック混乱するのでそのあたりの文字削除
 		$check = preg_replace('/\n|\r|\r\n|\t|\s/', '', $this->view);
-		$this->assertTextContains(
-			'<liclass="active"><ahref="/var/www/app/app/Console/user_manager/user_manager/edit/2">',
+		$this->assertRegExp(
+			'/<liclass="active"><ahref=".*?\/user_manager\/user_manager\/edit\/2">/',
 			$check
 		);
 	}

--- a/Test/Case/Controller/UserManagerController/EditTest.php
+++ b/Test/Case/Controller/UserManagerController/EditTest.php
@@ -246,12 +246,16 @@ class UserManagerControllerEditTest extends UserManagerControllerTestCase {
 
 		//テスト実行
 		$this->_testPostAction('put', $this->__data($userId),
-				array('action' => 'edit'), null, 'view');
+				array('action' => 'edit', 'key' => $userId), null, 'view');
 
 		//チェック
-		$header = $this->controller->response->header();
-		$pattern = '/user_manager/user_manager/index';
-		$this->assertTextContains($pattern, $header['Location']);
+		// 同じ画面にとどまっていることを確認する
+		// 改行コードや微妙な空白などの混在がチェック混乱するのでそのあたりの文字削除
+		$check = preg_replace('/\n|\r|\r\n|\t|\s/', '', $this->view);
+		$this->assertTextContains(
+			'<liclass="active"><ahref="/var/www/app/app/Console/user_manager/user_manager/edit/2">',
+			$check
+		);
 	}
 
 /**

--- a/View/UserManager/edit.ctp
+++ b/View/UserManager/edit.ctp
@@ -25,10 +25,15 @@
 	<?php echo $this->element('Users.Users/edit_form', array('element' => 'UserManager.UserManager/render_edit_row')); ?>
 
 	<div class="panel-footer text-center">
-		<?php echo $this->Button->cancelAndSave(
-				__d('net_commons', 'Cancel'),
+		<?php
+			$backTitle = 'Back to list';
+			if (! empty($query)) {
+				$backTitle = 'Back to search result list';
+			}
+			echo $this->Button->cancelAndSave(
+				__d('user_manager', $backTitle),
 				__d('net_commons', 'OK'),
-				NetCommonsUrl::actionUrlAsArray(array('action' => 'index'))
+				NetCommonsUrl::actionUrlAsArray(array('action' => 'index', '?' => $query))
 			); ?>
 	</div>
 

--- a/View/UsersRolesRooms/edit.ctp
+++ b/View/UsersRolesRooms/edit.ctp
@@ -35,10 +35,15 @@ echo $this->NetCommonsHtml->script([
 		</article>
 
 		<div class="text-center">
-			<?php echo $this->Button->cancelAndSave(
-					__d('net_commons', 'Cancel'),
+			<?php 
+				$backTitle = 'Back to list';
+				if (! empty($query)) {
+					$backTitle = 'Back to search result list';
+				}
+				echo $this->Button->cancelAndSave(
+					__d('user_manager', $backTitle),
 					__d('net_commons', 'OK'),
-					NetCommonsUrl::actionUrlAsArray(['controller' => 'user_manager', 'action' => 'index'])
+					NetCommonsUrl::actionUrlAsArray(['controller' => 'user_manager', 'action' => 'index', '?' => $query])
 				); ?>
 		</div>
 


### PR DESCRIPTION
会員管理で会員情報の編集画面、参加ルームの編集画面でいずれも「決定」で現画面にとどまるように変更
検索で絞り込んで一覧表示したとき、検索条件をセッションに記憶するようにした。
編集画面ではセッションに絞り込んだ検索条件があるかどうかで、「キャンセル」ボタンではなく「一覧に戻る」または「絞り込み一覧に戻る」のボタン名に変更